### PR TITLE
refactor: update Priority and TaskCard components to use TaskPriority enum for consistency

### DIFF
--- a/app/src/main/java/com/giraffe/tudeeapp/design_system/component/Priority.kt
+++ b/app/src/main/java/com/giraffe/tudeeapp/design_system/component/Priority.kt
@@ -7,26 +7,27 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import com.giraffe.tudeeapp.R
 import com.giraffe.tudeeapp.design_system.theme.Theme
+import com.giraffe.tudeeapp.domain.model.task.TaskPriority
 
 
 @Composable
 fun Priority(
-    priorityType: PriorityType,
+    priorityType: TaskPriority,
     isSelected: Boolean,
     modifier: Modifier = Modifier
 ) {
     var icon: Int
     var label: String
     when (priorityType) {
-        PriorityType.HIGH -> {
+        TaskPriority.HIGH -> {
             icon = R.drawable.flag_icon; label = stringResource(R.string.high)
         }
 
-        PriorityType.MEDIUM -> {
+        TaskPriority.MEDIUM -> {
             icon = R.drawable.alert_icon; label = stringResource(R.string.medium)
         }
 
-        PriorityType.LOW -> {
+        TaskPriority.LOW -> {
             icon = R.drawable.trade_down_icon; label = stringResource(R.string.low)
         }
     }
@@ -45,13 +46,7 @@ fun Priority(
 @Composable
 fun PriorityPreview() {
     Priority(
-        priorityType = PriorityType.HIGH,
+        priorityType = TaskPriority.HIGH,
         isSelected = true
     )
-}
-
-enum class PriorityType {
-    HIGH,
-    MEDIUM,
-    LOW
 }

--- a/app/src/main/java/com/giraffe/tudeeapp/design_system/component/TabsBar.kt
+++ b/app/src/main/java/com/giraffe/tudeeapp/design_system/component/TabsBar.kt
@@ -33,14 +33,13 @@ import com.giraffe.tudeeapp.domain.model.task.TaskStatus
 fun TabsBar(
     modifier: Modifier = Modifier,
     onTabSelected: (TaskStatus) -> Unit = {},
-    todoTasksCount: Int = 0,
-    inProgressTasksCount: Int = 14,
-    doneTasksCount: Int = 0,
+    tasks: Map<TaskStatus, Int> = mapOf()
 ) {
     val startTab = TaskStatus.IN_PROGRESS
     var selectedTab by rememberSaveable { mutableIntStateOf(startTab.ordinal) }
     PrimaryTabRow(
         modifier = modifier,
+        containerColor = Theme.color.surfaceHigh,
         selectedTabIndex = selectedTab,
         indicator = {
             TabRowDefaults.PrimaryIndicator(
@@ -51,17 +50,18 @@ fun TabsBar(
             )
         }
     ) {
-        TaskStatus.entries.forEachIndexed { index, tab ->
-            val tasksCount = when (tab) {
-                TaskStatus.TODO -> todoTasksCount
-                TaskStatus.IN_PROGRESS -> inProgressTasksCount
-                TaskStatus.DONE -> doneTasksCount
+        tasks.forEach { tab ->
+            val title = when (tab.key) {
+                TaskStatus.TODO -> "To Do"
+                TaskStatus.IN_PROGRESS -> "In progress"
+                TaskStatus.DONE -> "Done"
             }
+            val index = tab.key.ordinal
             Tab(
                 selected = selectedTab == index,
                 onClick = {
                     selectedTab = index
-                    onTabSelected(tab)
+                    onTabSelected(tab.key)
                 },
                 selectedContentColor = Theme.color.title,
                 unselectedContentColor = Theme.color.hint,
@@ -74,13 +74,13 @@ fun TabsBar(
                             modifier = Modifier
                                 .weight(.73f),
                             textAlign = TextAlign.Center,
-                            text = tab.name,
+                            text = title,
                             maxLines = 1,
                             overflow = TextOverflow.Ellipsis,
                             style = if (selectedTab == index) Theme.textStyle.label.medium else Theme.textStyle.label.small,
                         )
 
-                        if (tasksCount != 0) {
+                        if (tab.value != 0) {
                             Box(
                                 modifier = Modifier
                                     .weight(.27f)
@@ -90,7 +90,7 @@ fun TabsBar(
                                 contentAlignment = Alignment.Center
                             ) {
                                 Text(
-                                    text = tasksCount.toString(),
+                                    text = tab.value.toString(),
                                     style = Theme.textStyle.label.medium,
                                     color = Theme.color.body
                                 )

--- a/app/src/main/java/com/giraffe/tudeeapp/design_system/component/TaskCard.kt
+++ b/app/src/main/java/com/giraffe/tudeeapp/design_system/component/TaskCard.kt
@@ -25,12 +25,13 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.giraffe.tudeeapp.R
 import com.giraffe.tudeeapp.design_system.theme.Theme
+import com.giraffe.tudeeapp.domain.model.task.TaskPriority
 
 @Composable
 fun TaskCard(
     taskIcon: Painter,
     blurColor: Color,
-    priority: PriorityType,
+    priority: TaskPriority,
     taskTitle: String,
     taskDescription: String,
     taskCardType: TaskCardType,
@@ -81,18 +82,18 @@ fun TaskCard(
                     )
                 }
                 when (priority) {
-                    PriorityType.HIGH -> Priority(
-                        priorityType = PriorityType.HIGH,
+                    TaskPriority.HIGH -> Priority(
+                        priorityType = TaskPriority.HIGH,
                         isSelected = true
                     )
 
-                    PriorityType.MEDIUM -> Priority(
-                        priorityType = PriorityType.MEDIUM,
+                    TaskPriority.MEDIUM -> Priority(
+                        priorityType = TaskPriority.MEDIUM,
                         isSelected = true
                     )
 
-                    PriorityType.LOW -> Priority(
-                        priorityType = PriorityType.HIGH,
+                    TaskPriority.LOW -> Priority(
+                        priorityType = TaskPriority.HIGH,
                         isSelected = true
                     )
                 }
@@ -127,7 +128,7 @@ fun TaskCardPreview() {
         TaskCard(
             taskIcon = painterResource(R.drawable.birthday_cake_icon),
             blurColor = Theme.color.pinkAccent.copy(alpha = .08f),
-            priority = PriorityType.HIGH,
+            priority = TaskPriority.HIGH,
             taskTitle = "Organize Study Desk",
             taskDescription = "Review cell structure and functions for tomorrow...",
             date = "12-03-2025",


### PR DESCRIPTION
- pass map of task that consist of TaskStatus as a key and the tasks count of status this status, to reduce the number of params that have been passed to this composable .
- use TaskPriority instead of PriorityType and delete PriorityType because there no reason to be created it is similar exactly to TaskPriority of domain.